### PR TITLE
Add renameUpload ajax-functionality

### DIFF
--- a/src/components/vue-file-agent-mixin.js
+++ b/src/components/vue-file-agent-mixin.js
@@ -101,6 +101,12 @@ export default {
       }
       return uploader.deleteUpload(url, headers, fileData, uploadData);
     },
+    renameUpload(url, headers, fileData, uploadData){
+      if(this.filesData.length < 1){
+        this.overallProgress = 0;
+      }
+      return uploader.renameUpload(url, headers, fileData, uploadData);
+    },
     autoUpload(filesData){
       if(!this.uploadUrl){
         return;
@@ -112,6 +118,12 @@ export default {
         return Promise.resolve(false);
       }
       return this.deleteUpload(this.uploadUrl, this.uploadHeaders, fileData);
+    },
+    autoRenameUpload(fileData){
+      if(!this.uploadUrl){
+        return Promise.resolve(false);
+      }
+      return this.renameUpload(this.uploadUrl, this.uploadHeaders, fileData);
     },
     equalFiles(file1, file2){
       return true &&
@@ -250,6 +262,11 @@ export default {
       this.$emit('delete', FileData.toRawArray([fileData])[0]);
       this.autoDeleteUpload(fileData).then((res)=> { }, (err)=> {
         this.filesData.splice(i, 1, fileData);
+      });
+    },
+    filenameChanged(fileData){
+      this.$emit('rename', FileData.toRawArray([fileData])[0]);
+      this.autoRenameUpload(fileData).then((res)=> { }, (err)=> {
       });
     },
     checkValue(){

--- a/src/components/vue-file-agent.vue
+++ b/src/components/vue-file-agent.vue
@@ -12,8 +12,8 @@
   <transition-group name="grid-box" tag="div" class="">
     <template v-for="(fileData, index) in filesData">
       <slot name="file-preview" v-bind:fileData="fileData" v-bind:index="index">
-        <VueFilePreview 
-          :value="fileData" :index="index" :deletable="isDeletable" :editable="editable === true" :errorText="errorText" :disabled="disabled" @remove="removeFileData($event)"
+        <VueFilePreview
+          :value="fileData" :index="index" :deletable="isDeletable" :editable="editable === true" :errorText="errorText" :disabled="disabled" @remove="removeFileData($event)" @rename="filenameChanged($event)"
            :key="fileData.id" class="file-preview-wrapper grid-box-item grid-block"></VueFilePreview>
       </slot>
     </template>

--- a/src/components/vue-file-preview.vue
+++ b/src/components/vue-file-preview.vue
@@ -145,8 +145,6 @@
       },
 
       editInputBlured(){
-        var value = this.$refs.input.value;
-        this.fileData.customName = value;
         var timeout = 100;
         setTimeout(()=> {
           this.$nextTick(()=> {
@@ -160,6 +158,12 @@
 
       filenameChanged(completed){
         if(completed){
+          var newValue = this.$refs.input.value;
+          var oldValue = this.fileData.customName ? this.fileData.customName : this.fileData.name(true);
+          if (newValue !== oldValue) {
+              this.fileData.customName = newValue;
+              this.$emit('rename', this.fileData);
+          }
           this.$refs.input.blur();
         }
         if(completed === false){

--- a/src/lib/ajax-request.js
+++ b/src/lib/ajax-request.js
@@ -132,6 +132,10 @@ class AjaxRequest {
     return this.request('DELETE', url, formData, configureFn);
   }
 
+  put(url, formData, configureFn = null){
+    return this.request('PUT', url, formData, configureFn);
+  }
+
 }
 
 export default new AjaxRequest();

--- a/src/lib/upload-helper.js
+++ b/src/lib/upload-helper.js
@@ -36,6 +36,17 @@ class UploadHelper {
     });
   }
 
+  doRenameUpload(url, headers, data, configureFn){
+    if (typeof data != 'string') {
+      data = JSON.stringify(data);
+    }
+    return ajax.put(url, data, (xhr)=> {
+      xhr.setRequestHeader('Content-Type', 'application/json');
+      this.addHeaders(xhr, headers);
+      configureFn(xhr);
+    });
+  }
+
   doUploadAxios(axios, formData, progressCallback){
     return axios.post('/upload', formData, {
       onUploadProgress: progressCallback,
@@ -118,6 +129,27 @@ class UploadHelper {
       }
       if (uploadData) {
         this.doDeleteUpload(url, headers, uploadData, (xhr)=> {
+        }).then((result)=> {
+          resolve(result);
+        }, (err)=> {
+          this.prepareUploadError(fileData, err);
+          reject(err);
+        });
+      }
+    });
+  }
+
+  renameUpload(url, headers, fileData, uploadData){
+    return new Promise((resolve, reject)=> {
+      if (fileData.xhr) {
+        fileData.xhr.abort();
+      }
+      if(uploadData === undefined){
+        uploadData = fileData.upload;
+        uploadData.customName = fileData.customName;
+      }
+      if (uploadData) {
+        this.doRenameUpload(url, headers, uploadData, (xhr)=> {
         }).then((result)=> {
           resolve(result);
         }, (err)=> {


### PR DESCRIPTION
Hi!

First of all thanks for making this! :)

You've recently added the functionality to rename a file, but the server only got that information, if the upload had not taken place yet (e.g. when using auto-upload).

With this pull request, i've changed that functionality to behave like file-deletion. A PUT request is fired now, when the name is changed and auto-upload is used.

Feel free to merge if you deem it useful!

Best wishes
Gerald