### PR TITLE
Add link to icon, if fileData.url is set and file is no media file

### DIFF
--- a/src/components/vue-file-preview.vue
+++ b/src/components/vue-file-preview.vue
@@ -39,7 +39,10 @@
         <span class="file-progress-bar" v-bind:style="{width: fileData.progress() + '%'}"></span>
       </span>
       <span class="file-icon">
-        <VueFileIcon :ext="fileData.ext()"></VueFileIcon>
+        <a v-if="linkUrl" v-bind:href="fileData.url" target="_blank" v-bind:title="fileData.customName ? fileData.customName : fileData.name">
+          <VueFileIcon :ext="fileData.ext()"></VueFileIcon>
+        </a>
+        <VueFileIcon v-else :ext="fileData.ext()"></VueFileIcon>
       </span>
     </span>
   </div>
@@ -63,6 +66,12 @@
       }
     },
     computed: {
+      linkUrl: function () {
+        return this.fileData.url &&
+          !this.fileData.isImage() &&
+          !this.fileData.isVideo() &&
+          !this.fileData.isAudio();
+      }
     },
     methods: {
       getFileData(){


### PR DESCRIPTION
I thought it would make sense wrap the file-icon with a link, if `fileData.url` is set, and the file is no image/video/audio file. Feel free to merge the commit, if you deem it useful!