### PR TITLE
Make photo files linkable

### DIFF
--- a/src/components/vue-file-preview-mixin.ts
+++ b/src/components/vue-file-preview-mixin.ts
@@ -20,12 +20,7 @@ export default Vue.extend({
       if (!this.linkable) {
         return false;
       }
-      return (
-        !!this.fileData.url &&
-        !this.fileData.isImage() &&
-        !this.fileData.isPlayableVideo() &&
-        !this.fileData.isPlayableAudio()
-      );
+      return !!this.fileData.url && !this.fileData.isPlayableVideo() && !this.fileData.isPlayableAudio();
     },
   },
   methods: {


### PR DESCRIPTION
Currently, if a preloaded file has a url set, and is not a photo, playable video, or playable audio, it is linkable in vue-file-preview component.

It makes sense for playable videos and playable audio to not be linkable, as clicking them instead initiates playing the file. But it doesn't make sense that photos are not linkable when they have not other expected action when clicked.

This PR makes photos linkable.