### PR TITLE
Applied crossOrigin="use-credentials" to preview image and video

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -77,7 +77,7 @@ class Utils {
     thumbnailSize: number,
     calculateAverageColor?: boolean,
   ): Promise<VideoThumbnail> {
-    video.setAttribute('crossOrigin', 'anonymous'); // fix cross origin issue
+    video.setAttribute('crossOrigin', 'use-credentials'); // fix cross origin issue
     return new Promise((resolve, reject) => {
       let loadedmetadata = false;
       let loadeddata = false;
@@ -369,7 +369,7 @@ class Utils {
     calculateAverageColor?: boolean,
   ): Promise<ImageThumbnail | null> {
     const image = new Image();
-    image.setAttribute('crossOrigin', 'anonymous');
+    image.setAttribute('crossOrigin', 'use-credentials');
     return url
       ? this.resizeImageUrl(image, url, thumbnailSize, calculateAverageColor)
       : this.resizeImageFile(image, file as File, thumbnailSize, calculateAverageColor);


### PR DESCRIPTION
Hi @safrazik, here is the hotfix for #89, it'd be great if you can merge it to the `master` for now, will see if I have time to contribute more i.e. add the new props `crossOrigin` to vue-file-agent in the next couple of weeks. Cheers!