### PR TITLE
Support uploadWithCredentials option when using tus

### DIFF
--- a/src/components/vue-file-agent-mixin.ts
+++ b/src/components/vue-file-agent-mixin.ts
@@ -195,6 +195,7 @@ export default Vue.extend({
             this.overallProgress = overallProgress;
           },
           this.resumable === true ? undefined : this.resumable,
+          this.uploadWithCredentials,
         );
       }
       return new Promise((resolve, reject) => {

--- a/src/lib/upload-helper.ts
+++ b/src/lib/upload-helper.ts
@@ -319,9 +319,9 @@ class UploadHelper {
           resolve(upload);
         },
         onBeforeRequest: function (req) {
-					var xhr = req.getUnderlyingObject()
-					xhr.withCredentials = uploadWithCredentials;
-				},
+            var xhr = req.getUnderlyingObject()
+            xhr.withCredentials = uploadWithCredentials;
+        },
       });
       fileRecord.tusUpload = upload;
       // Start the upload

--- a/src/lib/upload-helper.ts
+++ b/src/lib/upload-helper.ts
@@ -287,6 +287,7 @@ class UploadHelper {
     headers: object,
     progressCallback: ProgressFn,
     tusOptionsFn?: TusOptionsFn,
+    uploadWithCredentials?: boolean,
   ) {
     const tusOptions: TusOptions = tusOptionsFn ? tusOptionsFn(fileRecord) : {};
     return new Promise((resolve, reject) => {
@@ -317,6 +318,10 @@ class UploadHelper {
         onSuccess() {
           resolve(upload);
         },
+        onBeforeRequest: function (req) {
+					var xhr = req.getUnderlyingObject()
+					xhr.withCredentials = uploadWithCredentials;
+				},
       });
       fileRecord.tusUpload = upload;
       // Start the upload
@@ -331,6 +336,7 @@ class UploadHelper {
     fileRecords: FileRecord[],
     progressFn?: (progress: number) => void,
     tusOptionsFn?: TusOptionsFn,
+    uploadWithCredentials?: boolean,
   ) {
     let updateOverallProgress = () => {
       /* no op */
@@ -358,6 +364,7 @@ class UploadHelper {
           updateOverallProgress();
         },
         tusOptionsFn,
+        uploadWithCredentials,
       );
       promise.then(
         (response) => {

--- a/types/src/lib/upload-helper.d.ts
+++ b/types/src/lib/upload-helper.d.ts
@@ -18,7 +18,7 @@ declare class UploadHelper {
     updateUpload(url: string, headers: object, fileRecord: FileRecord, uploadData: any, configureFn?: ConfigureFn): Promise<unknown>;
     doTusUpload(tus: any, url: string, fileRecord: FileRecord, headers: object, progressCallback: ProgressFn, tusOptionsFn?: TusOptionsFn, uploadWithCredentials?: boolean): Promise<unknown>;
     tusUpload(tus: any, url: string, headers: object, fileRecords: FileRecord[], progressFn?: (progress: number) => void, tusOptionsFn?: TusOptionsFn, uploadWithCredentials?: boolean): Promise<unknown[]>;
-    tusDeleteUpload(tus: any, url: string, headers: object, fileRecord: FileRecord, uploadWithCredentials?: boolean): Promise<unknown>;
+    tusDeleteUpload(tus: any, url: string, headers: object, fileRecord: FileRecord): Promise<unknown>;
 }
 declare const _default: UploadHelper;
 export default _default;

--- a/types/src/lib/upload-helper.d.ts
+++ b/types/src/lib/upload-helper.d.ts
@@ -16,9 +16,9 @@ declare class UploadHelper {
     upload(url: string, headers: object, fileRecords: FileRecord[], createFormData?: CreateFormDataFn, progressFn?: (progress: number) => void, configureFn?: ConfigureFn): Promise<unknown>;
     deleteUpload(url: string, headers: object, fileRecord: FileRecord, uploadData?: any, configureFn?: ConfigureFn): Promise<unknown>;
     updateUpload(url: string, headers: object, fileRecord: FileRecord, uploadData: any, configureFn?: ConfigureFn): Promise<unknown>;
-    doTusUpload(tus: any, url: string, fileRecord: FileRecord, headers: object, progressCallback: ProgressFn, tusOptionsFn?: TusOptionsFn): Promise<unknown>;
-    tusUpload(tus: any, url: string, headers: object, fileRecords: FileRecord[], progressFn?: (progress: number) => void, tusOptionsFn?: TusOptionsFn): Promise<unknown[]>;
-    tusDeleteUpload(tus: any, url: string, headers: object, fileRecord: FileRecord): Promise<unknown>;
+    doTusUpload(tus: any, url: string, fileRecord: FileRecord, headers: object, progressCallback: ProgressFn, tusOptionsFn?: TusOptionsFn, uploadWithCredentials?: boolean): Promise<unknown>;
+    tusUpload(tus: any, url: string, headers: object, fileRecords: FileRecord[], progressFn?: (progress: number) => void, tusOptionsFn?: TusOptionsFn, uploadWithCredentials?: boolean): Promise<unknown[]>;
+    tusDeleteUpload(tus: any, url: string, headers: object, fileRecord: FileRecord, uploadWithCredentials?: boolean): Promise<unknown>;
 }
 declare const _default: UploadHelper;
 export default _default;


### PR DESCRIPTION
This PR makes vue-file-agent pass the `uploadWithCredentials` option to the tus client. Prevously there was no way for tus to have this setting changed.

The way it is done follows [the tus 2.x documentation](https://github.com/tus/tus-js-client/blob/32b3544b7f04601d1d51aaa1eed12921f0a685ec/docs/api.md#onbeforerequest).