### PR TITLE
* fix uploading image/vnd.* types (dxf, dwg, ...)

### DIFF
--- a/src/lib/file-record.ts
+++ b/src/lib/file-record.ts
@@ -300,7 +300,7 @@ class FileRecord {
   }
 
   public isImage(): boolean {
-    return this.file && this.file.type.indexOf('image') !== -1;
+    return this.file && !!this.file.type.match(/image((?!vnd).)*$/i);
   }
 
   public isVideo(): boolean {


### PR DESCRIPTION
MIME types with vnd.* contain `image` word but are not resizable.
Extensions like *.dxf, *.dwg does not work.

