### PR TITLE
Allow using tus client v1.x or v2.x

### DIFF
--- a/src/lib/upload-helper.ts
+++ b/src/lib/upload-helper.ts
@@ -391,14 +391,23 @@ class UploadHelper {
       // const shouldTerminate = true;
       const abort = (shouldTerminate: boolean) => {
         return new Promise((res, rej) => {
-          fileRecord.tusUpload.abort(shouldTerminate, (err: any) => {
-            if (err) {
+          // If using tus-upload-client v1.x, `abort` takes two arguments and the second is a callback.
+          // If using v2.x, it takes only one argument and returns a promise.
+          if (fileRecord.tusUpload.abort.length === 2) {
+            fileRecord.tusUpload.abort(shouldTerminate, (err: any) => {
+              if (err) {
+                this.prepareUploadError(fileRecord, err);
+                rej(err);
+                return;
+              }
+              res();
+            });
+          } else {
+            fileRecord.tusUpload.abort(shouldTerminate).then(res, (err: any) => {
               this.prepareUploadError(fileRecord, err);
               rej(err);
-              return;
-            }
-            res();
-          });
+            });
+          }
         });
       };
       abort(false).then(() => {


### PR DESCRIPTION
Fixes #100, allowing both old 1.x and new 2.x [tus-js-client](https://github.com/tus/tus-js-client) versions to be used.