### PR TITLE
Fixes a malformedURI error

### DIFF
--- a/src/scss/_file-preview.scss
+++ b/src/scss/_file-preview.scss
@@ -30,7 +30,7 @@
     .file-preview-img {
       max-width: 100%;
       max-height: 100%;
-      background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" viewBox="0 0 16 16"><rect x="0" y="0" width="100%" height="100%" fill="rgba(255, 255, 255, 0.1)" /><rect x="50%" y="0" width="50%" height="50%" fill="rgba(0, 0, 0, 0.075)" /><rect x="0" y="50%" width="50%" height="50%" fill="rgba(0, 0, 0, 0.075)" /></svg>');
+      background-image: url("data:image/svg+xml,,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 16 16'%3E%3Crect x='0' y='0' width='100%25' height='100%25' fill='rgba(255, 255, 255, 0.1)' /%3E%3Crect x='50%25' y='0' width='50%25' height='50%25' fill='rgba(0, 0, 0, 0.075)' /%3E%3Crect x='0' y='50%25' width='50%25' height='50%25' fill='rgba(0, 0, 0, 0.075)' /%3E%3C/svg%3E");
       background-repeat: repeat;
       position: absolute;
       left: 50%;


### PR DESCRIPTION
My webpack CSS-loader started throwing an error today that `vue-file-agent.css` has a malformed URI. I tracked it down to this one line here. I don't know why this started today, I've had zero issues with this for the past several months, I can only assume that css-loader changed something today. Anyway, I tested this locally all I did was encode the svg uri and it works again.

Honestly I'm not sure if this is a *me* issue or not, but I figure if the encoding fixes an edge case and it still works for everyone else than it might be good to let you see it and decide if you want to pull in these changes. 

Thanks for this product, it's awesome!