### PR TITLE
Changed isImage() to return false for WMF files

### DIFF
--- a/src/lib/file-record.ts
+++ b/src/lib/file-record.ts
@@ -301,7 +301,7 @@ class FileRecord {
   }
 
   public isImage(): boolean {
-    return this.file && !!this.file.type.match(/image((?!vnd).)*$/i);
+    return this.file && this.file.type !== 'image/x-wmf' && !!this.file.type.match(/image((?!vnd).)*$/i);
   }
 
   public isVideo(): boolean {


### PR DESCRIPTION
As the WMF images can not be viewed in HTML, they should not be marked as image type.
Being treated as viewable image format while not being able to preview caused VueFileAgent to not update its value (file list).
This was fixed by returning false for type image/x-wmf.

I attached example WMF file in zip archive.
[Sideview.zip](https://github.com/safrazik/vue-file-agent/files/8069356/Sideview.zip)